### PR TITLE
make color code work on ptt/ptt2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const colorMap = {
 const colorNode = (node, content) => {
   Object.keys(colorMap).some((key) => {
     if (node.classList.contains(key)) {
-      content = `\u001b[${colorMap[key]}m${content}\u001b[m`;
+      content = `\u0015[${colorMap[key]}m${content}\u0015[m`;
       return true;
     }
   });


### PR DESCRIPTION
Although on terminal, color code works start with `^[` (`\u001b`), but when using article editor on ptt or ptt2, rather than directly sending `^[`, the way to insert a `^[` char is to send `^u` (`\u0015`), according to the colored text guide of ptt/ptt2.